### PR TITLE
Fixed issue with prices of assets due to changes of the api

### DIFF
--- a/.changeset/grumpy-vans-leave.md
+++ b/.changeset/grumpy-vans-leave.md
@@ -1,0 +1,5 @@
+---
+"@poktscan/extension": patch
+---
+
+Fixed issue with prices of assets due to changes of the api

--- a/apps/nodejs/extension/src/redux/slices/app/index.ts
+++ b/apps/nodejs/extension/src/redux/slices/app/index.ts
@@ -73,6 +73,7 @@ export interface IAsset {
   mintContractAddress?: string;
   decimals: 6;
   iconUrl: string;
+  coinGeckoId?: string;
   /**only presented in wPOKT assets at the moment*/
   vaultAddress?: string;
 }

--- a/apps/nodejs/extension/src/redux/slices/prices.ts
+++ b/apps/nodejs/extension/src/redux/slices/prices.ts
@@ -7,23 +7,7 @@ export const pricesApi = createApi({
     getPrices: builder.query({
       query: (ids: string) => `simple/price?ids=${ids}&vs_currencies=usd`,
     }),
-    getAssetPrices: builder.query({
-      query: ({
-        platformId,
-        contractAddresses,
-      }: {
-        platformId: string;
-        contractAddresses: string;
-      }) =>
-        `simple/token_price/${platformId}?contract_addresses=${contractAddresses}&vs_currencies=usd`,
-      keepUnusedDataFor: 60 * 3,
-    }),
   }),
 });
 
-export const {
-  useGetPricesQuery,
-  useLazyGetPricesQuery,
-  useGetAssetPricesQuery,
-  useLazyGetAssetPricesQuery,
-} = pricesApi;
+export const { useGetPricesQuery, useLazyGetPricesQuery } = pricesApi;


### PR DESCRIPTION
The prices API was not accepting more than one contract address in the assets endpoint. Instead of using the assets endpoint, I added the coin id to the assets json in the CDN to use the coins endpoint.