### PR TITLE
Revert "Bump vite from 4.5.1 to 4.5.3"

### DIFF
--- a/.changeset/tidy-parrots-hug.md
+++ b/.changeset/tidy-parrots-hug.md
@@ -1,5 +1,0 @@
----
-"@soothe/extension": patch
----
-
-Bumps vite from 4.5.1 to 4.5.3.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10473,9 +10473,9 @@ vite-node@0.32.0:
     vite "^3.0.0 || ^4.0.0"
 
 "vite@^3.0.0 || ^4.0.0":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.3.tgz#d88a4529ea58bae97294c7e2e6f0eab39a50fb1a"
-  integrity sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.1.tgz#3370986e1ed5dbabbf35a6c2e1fb1e18555b968a"
+  integrity sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==
   dependencies:
     esbuild "^0.18.10"
     postcss "^8.4.27"


### PR DESCRIPTION
Reverts pokt-scan/soothe-vault#50

The original PR had outdated code.