### PR TITLE
Update CDN URLs in .env.template

### DIFF
--- a/apps/nodejs/extension/.env.template
+++ b/apps/nodejs/extension/.env.template
@@ -5,8 +5,8 @@ PROVIDER_INFO_RDNS=io.trustsoothe
 WPOKT_TESTNET_API_BASE_URL=https://testnet-wpokt.vercel.app/api
 WPOKT_MAINNET_API_BASE_URL=https://wpokt.network/api
 PRICE_API_BASE_URL=https://api.coingecko.com/api/v3/
-NETWORKS_CDN_URL=https://poktscan-v1.nyc3.cdn.digitaloceanspaces.com/networks.json
-ASSETS_CDN_URL=https://poktscan-v1.nyc3.cdn.digitaloceanspaces.com/assets.json
+NETWORKS_CDN_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/networks.json
+ASSETS_CDN_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/assets.json
 
 # The envs below are for showing a label and an image for each chain in the extension when doing stake transactions
 POKT_MAINNET_CHAIN_MAPS_URL=https://poktscan-v1.nyc3.digitaloceanspaces.com/pokt-chains-map.json


### PR DESCRIPTION
Replaced outdated URLs with new CDN links pointing to "soothe-vault". This ensures the extension accesses the updated resources for networks and assets.