### PR TITLE
Reconfigures dotenv-webpack

### DIFF
--- a/.changeset/calm-cups-greet.md
+++ b/.changeset/calm-cups-greet.md
@@ -1,0 +1,5 @@
+---
+"@soothe/extension": patch
+---
+
+Adds "systemvars" option on DotEnv-Webpack.

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -18,12 +18,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - name: Install Dependencies
-        run: yarn
       - name: Create Release Pull Request
         id: changeset
         uses: changesets/action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ yarn-error.log*
 
 # local env files
 .env
-.env\.(?!template)
+.env\.(?!example)
 
 # turbo
 .turbo

--- a/apps/nodejs/extension/.env.example
+++ b/apps/nodejs/extension/.env.example
@@ -9,6 +9,6 @@ NETWORKS_CDN_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/networks.j
 ASSETS_CDN_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/assets.json
 
 # The envs below are for showing a label and an image for each chain in the extension when doing stake transactions
-POKT_MAINNET_CHAIN_MAPS_URL=https://poktscan-v1.nyc3.digitaloceanspaces.com/pokt-chains-map.json
-POKT_TESTNET_CHAIN_MAPS_URL=https://poktscan-v1.nyc3.digitaloceanspaces.com/pokt-testnet-chains-map.json
-CHAIN_IMAGES_CDN_URL=https://poktscan-v1.nyc3.digitaloceanspaces.com/chains-images
+POKT_MAINNET_CHAIN_MAPS_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/pokt-chains-map.json
+POKT_TESTNET_CHAIN_MAPS_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/pokt-testnet-chains-map.json
+CHAIN_IMAGES_CDN_URL=https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/chains-images

--- a/apps/nodejs/extension/README.md
+++ b/apps/nodejs/extension/README.md
@@ -2,7 +2,7 @@
 
 ## Envs
 
-Please create a .env file from the .env.template file and change the values to your needs.
+Please create a .env file from the .env.example file and change the values to your needs.
 
 ## Build
 

--- a/apps/nodejs/extension/build/webpack/common.js
+++ b/apps/nodejs/extension/build/webpack/common.js
@@ -17,7 +17,7 @@ const getManifest = require("../manifest");
 
   for (const env of requiredEnvs) {
     if (!process.env[env]) {
-      throw new Error(`Missing required env: ${env}`)
+      throw new Error(`Missing required env: ${env} on the system.`)
     }
   }
 })()
@@ -167,6 +167,7 @@ module.exports = {
       resource.request = resource.request.replace(/^node:/, "");
     }),
     new Dotenv({
+      safe: true,
       systemvars: true,
     }),
   ],

--- a/apps/nodejs/extension/build/webpack/common.js
+++ b/apps/nodejs/extension/build/webpack/common.js
@@ -166,6 +166,8 @@ module.exports = {
     new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
       resource.request = resource.request.replace(/^node:/, "");
     }),
-    new Dotenv(),
+    new Dotenv({
+      systemvars: true,
+    }),
   ],
 };


### PR DESCRIPTION
- Activates safe mode
- Renames .env.template to .env.example so that it is used by dotenv-webpack to validate.
- Removed node setup from the version packages workflow