### PR TITLE
Updated readme and added `build:chromium` and `build:firefox` scripts to base package.json

### DIFF
--- a/.changeset/six-lobsters-obey.md
+++ b/.changeset/six-lobsters-obey.md
@@ -1,0 +1,10 @@
+---
+"@soothe/extension": patch
+---
+
+* Updated `package.json` to include the following scripts:
+    - `build:chromium`: to build the extension for chromium based browsers
+    - `build:firefox`: to build the extension for firefox browser
+
+* Updated README.md to specify the build commands for the extension and the result location
+* Updated README.md of the extension to clarify how to inject the content scripts automatically in Firefox.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Before start running the code you must:
   command: `npm install yarn@1.22.19`.
 - Install all the dependencies running `yarn install` or `yarn`.
 
+## Build
+
+- To build the extension for `Chromium` based browsers, run `yarn build:chrome`.
+- To build the extension for `Firefox` browser, run `yarn build:firefox`.
+
+The result of the build will be located at `apps/nodejs/extension/dist`.
+
 ## Apps and Packages
 
 This monorepo includes the following packages/apps:
@@ -55,6 +62,3 @@ This monorepo includes the following packages/apps:
 - `vault-specs`: Automated Specs for the Universal Crypto Wallet Manager.
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
-### Build
-
-To build all apps and packages, run the following command: `yarn build`.

--- a/apps/nodejs/extension/README.md
+++ b/apps/nodejs/extension/README.md
@@ -51,8 +51,9 @@ dist folder will be keep updated.
 3. Click `Load Temporary Add-on…` button.
 4. Open the dist folder result of the first step and select manifest.json file.
 
-After the 4 step the extension is installed. But to inject the content scripts you need to open the extension in every
-tab you want it to be injected. To inject the content scripts automatically in every tab you must:
+After the 4 step the extension is installed. But to inject the content scripts you need to open the extension (click on
+the popup icon) in every
+tab you want it to be injected. To avoid this and inject the content scripts automatically in every tab you must:
 
 1. Go to the following url: about:addons
 2. Click the more button at the right of Soothe Vault and click `Manage` in the menu that will open.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "lint": "turbo run lint --concurrency=100%",
     "lint:fix": "turbo run lintfix --concurrency=100%",
     "build": "turbo run build --concurrency=100%",
+    "build:chromium": "turbo run build:chromium --concurrency=100%",
+    "build:firefox": "turbo run build:firefox --concurrency=100%",
     "build:autopolicy": "turbo run build:autopolicy --concurrency=100%",
     "dev": "turbo run dev --concurrency=100%",
     "build:ci": "./build-ci.sh",

--- a/turbo.json
+++ b/turbo.json
@@ -3,28 +3,74 @@
   "pipeline": {
     "build": {
       "cache": false,
-      "dependsOn": ["^build"],
-      "inputs": ["src/**"],
-      "outputs": ["dist/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "build:chromium": {
+      "cache": false,
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "build:firefox": {
+      "cache": false,
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "build:autopolicy": {
       "cache": false,
-      "dependsOn": ["^build:autopolicy"],
-      "inputs": ["src/**"],
-      "outputs": ["dist/**"]
+      "dependsOn": [
+        "^build:autopolicy"
+      ],
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "release:chromium": {
       "cache": false,
-      "inputs": ["src/**"],
-      "outputs": ["dist/**"]
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "release:firefox": {
       "cache": false,
-      "inputs": ["src/**"],
-      "outputs": ["dist/**"]
+      "inputs": [
+        "src/**"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     },
     "ci:test": {},
     "lint": {
@@ -37,12 +83,16 @@
       "cache": false
     },
     "dev": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "cache": false
     },
     "clean": {
       "cache": false
     }
   },
-  "globalEnv": ["CI_ENV"]
+  "globalEnv": [
+    "CI_ENV"
+  ]
 }


### PR DESCRIPTION
* Updated `package.json` to include the following scripts:
    - `build:chromium`: to build the extension for chromium based browsers
    - `build:firefox`: to build the extension for firefox browser

* Updated README.md to specify the build commands for the extension and the result location
* Updated README.md of the extension to clarify how to inject the content scripts automatically in Firefox.
