### PR TITLE
Add s script to sort number arrays in Firefox runtime.js builds

### DIFF
--- a/.changeset/warm-adults-beam.md
+++ b/.changeset/warm-adults-beam.md
@@ -1,0 +1,5 @@
+---
+"@soothe/extension": patch
+---
+
+* Added a script to sort number arrays in Firefox runtime.js builds

--- a/apps/nodejs/extension/package.json
+++ b/apps/nodejs/extension/package.json
@@ -14,7 +14,7 @@
     "build": "yarn typecheck && NODE_ENV=production webpack --config build/webpack/production.js && yarn build:content-scripts",
     "build:chromium": "yarn build && yarn rename-lockdown:chromium",
     "build:analyze-bundle": "ANALYZE_BUNDLE=true yarn build",
-    "build:firefox": "BROWSER=Firefox yarn build && yarn rename-lockdown:firefox",
+    "build:firefox": "BROWSER=Firefox yarn build && yarn rename-lockdown:firefox && ./scripts/sort-js-number-arrays.sh ./dist/firefox/js/runtime.js",
     "build:autopolicy": "LAVAMOAT_AUTO_POLICY=true yarn build",
     "build:autopolicy:firefox": "LAVAMOAT_AUTO_POLICY=true BROWSER=Firefox yarn build:firefox",
     "build:autopolicy:chromium": "LAVAMOAT_AUTO_POLICY=true yarn build:chromium",

--- a/apps/nodejs/extension/scripts/sort-js-number-arrays.sh
+++ b/apps/nodejs/extension/scripts/sort-js-number-arrays.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This file exists because Firefox compare the content of the build submitted with the one they create locally, and the runtime.js
+# have array of numbers but the numbers are not always in the same order, causing differences between the builds.
+
+FILE="$1"
+
+if [ -z "$FILE" ]; then
+  echo "Usage: $0 <file.js>"
+  exit 1
+fi
+
+# Create a temporary file
+temp_file=$(mktemp)
+
+# First, copy the file to preserve its contents
+cp "$FILE" "$temp_file"
+
+perl -i -pe '
+  BEGIN { binmode STDIN, ":utf8"; binmode STDOUT, ":utf8"; }
+  # Match arrays of numbers that appear after a string index, preserving structure
+  s{
+    (\["[^"]+",\[)        # Match ["any string",[
+    (
+      (?:
+        \s*
+        -?\d+(?:\.\d+)?(?:e[+-]?\d+)?  # match number (int, float, or scientific)
+        \s*,?\s*
+      )+
+    )
+    (?=\])                # Lookahead for closing bracket
+  }{
+    my $prefix = $1;
+    my $numbers = $2;
+    $numbers =~ s/\s+//g;
+    $numbers =~ s/,\s*$//;
+    my @nums = split /,/, $numbers;
+    @nums = sort { $a <=> $b } @nums;
+    $prefix . join(",", @nums);
+  }egx;
+' "$temp_file"
+
+# Check if the temporary file is not empty before replacing
+if [ -s "$temp_file" ]; then
+    mv "$temp_file" "$FILE"
+    echo "✅ Sorted number arrays in $FILE"
+else
+    echo "❌ Error: Processing resulted in empty file, original file preserved"
+    rm "$temp_file"
+    exit 1
+fi


### PR DESCRIPTION
Introduce a Bash script to sort numeric arrays in runtime.js to ensure consistent builds for Firefox. Update the Firefox build command to use this script, preventing discrepancies between local and submitted builds.