### PR TITLE
Enhance Cosmos fee handling and transaction validation

### DIFF
--- a/.changeset/angry-insects-hammer.md
+++ b/.changeset/angry-insects-hammer.md
@@ -1,0 +1,12 @@
+---
+"@soothe/extension": minor
+"@soothe/vault": minor
+---
+
+Enhance Cosmos fee handling and transaction validation
+
+- Updated fee display logic for Cosmos when the recipient address, in send transaction form, is missing.
+- Introduced `decimal.js` dependency for precise calculations converting from upokt to pokt in Cosmos Shannon
+  operations.
+- Adjusted LavaMoat policy to support the new dependency.
+- Streamlined Cosmos transaction fee calculations.

--- a/apps/nodejs/extension/build/lavamoat/policy.json
+++ b/apps/nodejs/extension/build/lavamoat/policy.json
@@ -571,6 +571,7 @@
         "@soothe/vault>@pokt-foundation/pocketjs-types": true,
         "@scure/bip39": true,
         "buffer": true,
+        "decimal.js": true,
         "@soothe/vault>ed25519-hd-key": true,
         "@soothe/vault>ethereumjs-util": true,
         "@soothe/vault>hdkey": true,
@@ -902,7 +903,9 @@
     },
     "decimal.js": {
       "globals": {
-        "crypto": true
+        "crypto": true,
+        "define": true,
+        "self": true
       }
     },
     "assert>is-nan>define-properties>define-data-property": {

--- a/apps/nodejs/extension/src/ui/Transaction/BaseTransaction.tsx
+++ b/apps/nodejs/extension/src/ui/Transaction/BaseTransaction.tsx
@@ -134,7 +134,8 @@ export default function BaseTransaction({
     }
 
     if (
-      protocol === SupportedProtocols.Ethereum &&
+      (protocol === SupportedProtocols.Ethereum ||
+        protocol === SupportedProtocols.Cosmos) &&
       !isValidAddress(feeOptions?.to || getValues("recipientAddress"), protocol)
     ) {
       setValue("fee", null);
@@ -208,7 +209,9 @@ export default function BaseTransaction({
     status,
     protocol,
     chainId,
-    protocol === SupportedProtocols.Ethereum ? recipientAddress : null,
+    [SupportedProtocols.Ethereum, SupportedProtocols.Cosmos].includes(protocol)
+      ? recipientAddress
+      : null,
   ]);
 
   const onSubmit = async (data: TransactionFormValues) => {

--- a/apps/nodejs/extension/src/ui/Transaction/PoktFeeLabel.tsx
+++ b/apps/nodejs/extension/src/ui/Transaction/PoktFeeLabel.tsx
@@ -1,4 +1,4 @@
-import type { PocketNetworkFee } from "@soothe/vault";
+import { PocketNetworkFee, SupportedProtocols } from "@soothe/vault";
 import type { TransactionFormValues } from "./BaseTransaction";
 import React from "react";
 import Stack from "@mui/material/Stack";
@@ -14,7 +14,12 @@ interface PoktFeeLabelProps {
 export default function PoktFeeLabel({ marginTop }: PoktFeeLabelProps) {
   const { watch } = useFormContext<TransactionFormValues>();
 
-  const [networkFee, fetchingFee] = watch(["fee", "fetchingFee"]);
+  const [networkFee, fetchingFee, protocol, recipientAddress] = watch([
+    "fee",
+    "fetchingFee",
+    "protocol",
+    "recipientAddress",
+  ]);
 
   return (
     // todo: create component
@@ -49,11 +54,13 @@ export default function PoktFeeLabel({ marginTop }: PoktFeeLabelProps) {
             minWidth={0}
             textAlign={"right"}
           >
-            {roundAndSeparate(
-              (networkFee as PocketNetworkFee)?.value,
-              6,
-              "0.00"
-            )}
+            {protocol === SupportedProtocols.Cosmos && !recipientAddress
+              ? "-"
+              : roundAndSeparate(
+                  (networkFee as PocketNetworkFee)?.value,
+                  6,
+                  "0.00"
+                )}
           </Typography>
           <Typography>POKT</Typography>
         </Stack>

--- a/packages/nodejs/vault/package.json
+++ b/packages/nodejs/vault/package.json
@@ -51,6 +51,7 @@
     "@cosmjs/tendermint-rpc": "^0.33.1",
     "@metamask/eth-sig-util": "7.0.1",
     "@noble/ed25519": "2.0.0",
+    "decimal.js": "10.4.3",
     "@pokt-foundation/pocketjs-types": "2.1.3",
     "@scure/bip39": "^1.2.2",
     "ed25519-hd-key": "^1.3.0",

--- a/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/schemas.ts
+++ b/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/schemas.ts
@@ -2,11 +2,12 @@ import { z } from 'zod'
 import { COSMOS_PROTOCOL } from '../../values'
 import { CosmosTransactionTypes } from './CosmosTransactionTypes'
 import { SupportedProtocols } from '../../values'
-import { ConfigOptions, RPCType, SupplierServiceConfig } from './pocket/client/pocket/shared/service'
+import { ConfigOptions, RPCType } from './pocket/client/pocket/shared/service'
 import { coins } from '@cosmjs/proto-signing'
+import Decimal from 'decimal.js'
 
 function poktToUPoktCoin(amount: string) {
-  const amountInUpokt = (parseInt(amount) * 1e6).toString()
+  const amountInUpokt = new Decimal(amount).mul(1e6).toString()
   return coins(amountInUpokt, 'upokt')
 }
 


### PR DESCRIPTION
- Updated fee display logic for Cosmos when the recipient address, in send transaction form, is missing.
- Introduced `decimal.js` dependency for precise calculations converting from upokt to pokt in Cosmos Shannon
  operations.
- Adjusted LavaMoat policy to support the new dependency.
- Streamlined Cosmos transaction fee calculations.