### PR TITLE
Switch broadcast method from async to sync in Cosmos service

### DIFF
--- a/.changeset/forty-phones-act.md
+++ b/.changeset/forty-phones-act.md
@@ -1,0 +1,6 @@
+---
+"@soothe/vault": patch
+"@soothe/extension": patch
+---
+
+Switch broadcast method from async to sync in Cosmos service

--- a/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/CosmosProtocolService.ts
+++ b/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/CosmosProtocolService.ts
@@ -414,7 +414,7 @@ export class CosmosProtocolService
 
       const txBytes = Uint8Array.from(Buffer.from(transactionHex, "hex"));
 
-      const {hash}  = await tmClient.broadcastTxAsync({
+      const {hash}  = await tmClient.broadcastTxSync({
         tx: txBytes,
       });
 


### PR DESCRIPTION
Replaced `broadcastTxAsync` with `broadcastTxSync` to ensure immediate feedback on transaction submission. This change aligns the broadcast method with requirements for synchronous transaction handling.