### PR TITLE
Fixes/migrate and more import

### DIFF
--- a/.changeset/dry-snakes-brush.md
+++ b/.changeset/dry-snakes-brush.md
@@ -1,0 +1,7 @@
+---
+"@soothe/extension": patch
+"@soothe/vault": patch
+---
+
+- Removes requirement for balance when migrating morse accounts.
+- Uses default gas estimation value in cases where 'auto' was requested but there is not public key on chain

--- a/.changeset/smooth-donkeys-drive.md
+++ b/.changeset/smooth-donkeys-drive.md
@@ -1,0 +1,6 @@
+---
+"@soothe/extension": patch
+"@soothe/vault": patch
+---
+
+Refactor `ImportForm` to use `Controller` for `PasswordInput` binding with `useFormContext`

--- a/apps/nodejs/extension/src/ui/ImportAccount/ImportForm.tsx
+++ b/apps/nodejs/extension/src/ui/ImportAccount/ImportForm.tsx
@@ -163,7 +163,7 @@ export default function ImportForm({
             name={"json_file"}
             rules={{
               validate: async (value, formValues) => {
-                const selectedNetwork =  formValues.protocol && networks.find((n) => n.id === formValues.protocol);
+                const selectedNetwork =  formValues.protocol && networks.find((n) => n.protocol === formValues.protocol && n.isProtocolDefault);
                 if (formValues.import_type === "json_file") {
                   if (!value) {
                     return "Required";

--- a/apps/nodejs/extension/src/ui/ImportAccount/ImportForm.tsx
+++ b/apps/nodejs/extension/src/ui/ImportAccount/ImportForm.tsx
@@ -30,7 +30,7 @@ export default function ImportForm({
 }: ImportFormProps) {
   const selectedProtocol = useAppSelector(selectedProtocolSelector);
   const networks = useAppSelector(networksSelector);
-  const { control, setValue, clearErrors, register, watch } =
+  const { control, setValue, clearErrors, watch } =
     useFormContext<ImportAccountFormValues>();
   const [type] = watch(["import_type"]);
 
@@ -235,16 +235,22 @@ export default function ImportForm({
               </Stack>
             )}
           />
-          <PasswordInput
-            disabled={disableInputs}
-            placeholder={"File's Password (Optional)"}
-            canShowPassword={false}
-            error={wrongFilePassword}
-            helperText={wrongFilePassword ? "Invalid password" : undefined}
-            sx={{
-              marginTop: 2,
-            }}
-            {...register("file_password")}
+          <Controller
+              control={control}
+              name={"file_password"}
+              render={({ field }) => (
+                  <PasswordInput
+                      disabled={disableInputs}
+                      placeholder={"File's Password (Optional)"}
+                      canShowPassword={false}
+                      error={wrongFilePassword}
+                      helperText={wrongFilePassword ? "Invalid password" : undefined}
+                      sx={{
+                        marginTop: 2,
+                      }}
+                      {...field}
+                  />
+              )}
           />
         </>
       )}

--- a/apps/nodejs/extension/src/ui/Migration/MigrateAccount/MigrateAccountDialog.tsx
+++ b/apps/nodejs/extension/src/ui/Migration/MigrateAccount/MigrateAccountDialog.tsx
@@ -663,7 +663,6 @@ export default function MigrateAccountDialog({
         !!shannonAccount &&
         !!morseAccount &&
         morseAccount.shannon_dest_address === "" &&
-        morseAccount.unstaked_balance.amount !== "0" &&
         morseAccount.application_stake.amount === "0" &&
         morseAccount.supplier_stake.amount === "0"
       );

--- a/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
+++ b/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
@@ -79,7 +79,7 @@ export default function RecipientAutocomplete({
     "protocol",
     "fromAddress",
     "recipientProtocol",
-    fieldName,
+    fieldName as keyof TransactionFormValues,
   ]);
   const protocol = protocolFromProps || recipientProtocol || txProtocol;
 
@@ -192,12 +192,12 @@ export default function RecipientAutocomplete({
       return isValidPublicKey(value) || savedAddresses.includes(value);
     }
 
-    return isValidAddress(value, protocol);
+    return isValidAddress(value, protocol as SupportedProtocols);
   };
 
   const invalidValue = useMemo(() => {
     return !!inputValue &&
-    optionsMap[selectedAddress]?.name !== inputValue &&
+    optionsMap[selectedAddress as string]?.name !== inputValue &&
     !isValid(inputValue);
   }, [inputValue, optionsMap, selectedAddress]);
 

--- a/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
+++ b/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
@@ -79,7 +79,7 @@ export default function RecipientAutocomplete({
     "protocol",
     "fromAddress",
     "recipientProtocol",
-    "recipientAddress",
+    fieldName,
   ]);
   const protocol = protocolFromProps || recipientProtocol || txProtocol;
 
@@ -195,10 +195,11 @@ export default function RecipientAutocomplete({
     return isValidAddress(value, protocol);
   };
 
-  const invalidValue =
-    !!inputValue &&
+  const invalidValue = useMemo(() => {
+    return !!inputValue &&
     optionsMap[selectedAddress]?.name !== inputValue &&
     !isValid(inputValue);
+  }, [inputValue, optionsMap, selectedAddress]);
 
   return (
     <Controller

--- a/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/CosmosProtocolService.ts
+++ b/packages/nodejs/vault/src/lib/core/common/protocols/Cosmos/CosmosProtocolService.ts
@@ -325,7 +325,7 @@ export class CosmosProtocolService
     } catch (err) {
       console.error(err)
       return this.calculateFee({
-        gas: Number(estimatedGas),
+        gas: Number.isInteger(estimatedGas) ? Number(estimatedGas) : network.defaultGasEstimation ?? 200000,
         gasAdjustment,
         gasPrice,
       });


### PR DESCRIPTION
- Removes requirement for balance when migrating morse accounts.
- Uses default gas estimation value in cases where 'auto' was requested but there is not public key on chain
- Refactor `ImportForm` to use `Controller` for `PasswordInput` binding with `useFormContext`
