### PR TITLE
[BUG] Fixes TransactionDetailsModal crash

### DIFF
--- a/.changeset/polite-adults-teach.md
+++ b/.changeset/polite-adults-teach.md
@@ -1,0 +1,5 @@
+---
+"@soothe/extension": patch
+---
+
+Remove unused `fee` calculation and related UI elements from `TransactionDetailModal`

--- a/apps/nodejs/extension/src/ui/Activity/TransactionDetailModal.tsx
+++ b/apps/nodejs/extension/src/ui/Activity/TransactionDetailModal.tsx
@@ -371,10 +371,6 @@ function Content({ transaction }: ContentProps) {
     asset?.decimals || transaction.protocol === SupportedProtocols.Pocket
       ? 6
       : 18;
-  const fee =
-    transaction.protocol === SupportedProtocols.Ethereum
-      ? transaction.maxFeeAmount || 0
-      : transaction.fee;
 
   const firstSummaryRow: Array<SummaryRowItem> = [
     {
@@ -435,40 +431,7 @@ function Content({ transaction }: ContentProps) {
         />
       ),
     },
-    {
-      type: "row",
-      label: "Fee",
-      value: (
-        <AmountWithUsd
-          symbol={network.currencySymbol}
-          balance={fee}
-          usdBalance={usdPrice * fee}
-          isLoadingUsdPrice={isLoading}
-          decimals={decimals}
-        />
-      ),
-    },
   ];
-
-  if (!asset) {
-    const total = new Decimal(transaction.amount)
-      .add(new Decimal(fee))
-      .toNumber();
-
-    rows.push({
-      type: "row",
-      label: "Total",
-      value: (
-        <AmountWithUsd
-          symbol={coinSymbol}
-          balance={total}
-          usdBalance={usdPrice * total}
-          isLoadingUsdPrice={isLoading}
-          decimals={decimals}
-        />
-      ),
-    });
-  }
 
   const ActionBanner =
     transaction.status === TransactionStatus.Invalid


### PR DESCRIPTION
Remove unused `fee` calculation and related UI elements from `TransactionDetailModal`. This issue happens because the fee is not being stored with the transactions. 

Restoring this value will require changes in the way transactions results are handled internally in the vault.