### PR TITLE
Fixed Shannon selector in migration

### DIFF
--- a/.changeset/khaki-apples-provide.md
+++ b/.changeset/khaki-apples-provide.md
@@ -1,0 +1,5 @@
+---
+"@soothe/extension": patch
+---
+
+Removed functionality allowing to paste accounts not saved in the vault in the migration process.

--- a/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
+++ b/apps/nodejs/extension/src/ui/Transaction/RecipientAutocomplete.tsx
@@ -282,12 +282,6 @@ export default function RecipientAutocomplete({
             value={value || null}
             {...otherProps}
             inputValue={inputValue}
-            onBlur={() => {
-              if (!isValid(value)) {
-                onChange(inputValue);
-              }
-              otherProps.onBlur();
-            }}
             sx={{
               marginTop,
               "& .MuiAutocomplete-endAdornment": {


### PR DESCRIPTION
Removed functionality allowing to paste accounts not saved in the vault in the migration process.